### PR TITLE
Using IArangoContext interface instead of ArangoContext class

### DIFF
--- a/Core.Arango.Linq.Tests/UnitTest1.cs
+++ b/Core.Arango.Linq.Tests/UnitTest1.cs
@@ -18,7 +18,7 @@ namespace Core.Arango.Linq.Tests
 
     public class UnitTest1 : IAsyncLifetime
     {
-        protected readonly ArangoContext Arango =
+        protected readonly IArangoContext Arango =
             new ArangoContext($"Server=http://localhost:8529;Realm=CI-{Guid.NewGuid():D};User=root;Password=;");
 
         [Fact]

--- a/Core.Arango.Linq/ArangoProvider.cs
+++ b/Core.Arango.Linq/ArangoProvider.cs
@@ -10,11 +10,11 @@ namespace Core.Arango.Linq
 {
     public class ArangoProvider : IQueryProvider
     {
-        private readonly ArangoContext _arango;
+        private readonly IArangoContext _arango;
         private readonly string _collection;
         private readonly ArangoHandle _handle;
 
-        public ArangoProvider(ArangoContext arango, ArangoHandle handle, string collection)
+        public ArangoProvider(IArangoContext arango, ArangoHandle handle, string collection)
         {
             _arango = arango;
             _handle = handle;

--- a/Core.Arango.Linq/ArangoQueryableContext.cs
+++ b/Core.Arango.Linq/ArangoQueryableContext.cs
@@ -9,7 +9,7 @@ namespace Core.Arango.Linq
 {
     public class ArangoQueryableContext<T> : IOrderedQueryable<T>, IAsyncEnumerable<T>
     {
-        public ArangoQueryableContext(ArangoContext arango, ArangoHandle handle, string collection)
+        public ArangoQueryableContext(IArangoContext arango, ArangoHandle handle, string collection)
         {
             Provider = new ArangoProvider(arango, handle, collection);
             Expression = Expression.Constant(this);

--- a/Core.Arango.Linq/Extension.cs
+++ b/Core.Arango.Linq/Extension.cs
@@ -9,7 +9,7 @@ namespace Core.Arango.Linq
 {
     public static class ArangoLinqExtension
     {
-        public static IQueryable<T> AsQueryable<T>(this ArangoContext arango, ArangoHandle db, string collection = null)
+        public static IQueryable<T> AsQueryable<T>(this IArangoContext arango, ArangoHandle db, string collection = null)
         {
             return new ArangoQueryableContext<T>(arango, db, collection ?? typeof(T).Name);
         }


### PR DESCRIPTION
Using the interface will be a bit better because a lot of people using mostly interfaces, especially with DI.