### PR TITLE
Update to fix binary breaking change

### DIFF
--- a/Core.Arango.DataProtection/Core.Arango.DataProtection.csproj
+++ b/Core.Arango.DataProtection/Core.Arango.DataProtection.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl />
     <PackageProjectUrl>https://github.com/coronabytes/dotnet-arangodb-extensions</PackageProjectUrl>
     <PackageTags>aspnetcore dataprotection arangodb</PackageTags>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Core.Arango" Version="3.11.4" />
+    <PackageReference Include="Core.Arango" Version="3.11.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Core.Arango.DevExtreme/Core.Arango.DevExtreme.csproj
+++ b/Core.Arango.DevExtreme/Core.Arango.DevExtreme.csproj
@@ -5,7 +5,7 @@
     <Copyright>Andreas Dominik Jung</Copyright>
     <Authors>Andreas Dominik Jung</Authors>
     <Company>Corona Bytes</Company>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Description>Transforms DevExtreme's DataSourceLoadOptions to AQL syntax</Description>
     <PackageTags>arangodb devextreme</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-	<PackageReference Include="Core.Arango" Version="3.11.4" />
+	<PackageReference Include="Core.Arango" Version="3.11.5" />
 	<PackageReference Include="DevExtreme.AspNet.Data" Version="3.0.0" />
   </ItemGroup>
 

--- a/Core.Arango.Migration/Core.Arango.Migration.csproj
+++ b/Core.Arango.Migration/Core.Arango.Migration.csproj
@@ -5,7 +5,7 @@
     <Copyright>Andreas Dominik Jung</Copyright>
     <Authors>Andreas Dominik Jung</Authors>
     <Company>Corona Bytes</Company>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Description>EntityFramework like migrations for ArangoDB</Description>
     <PackageTags>arangodb migration</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-	  <PackageReference Include="Core.Arango" Version="3.11.4" />
+	  <PackageReference Include="Core.Arango" Version="3.11.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Core.Arango.Serilog/Core.Arango.Serilog.csproj
+++ b/Core.Arango.Serilog/Core.Arango.Serilog.csproj
@@ -11,7 +11,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIcon>ArangoDB.png</PackageIcon>
     <PackageIconUrl />
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <PackageProjectUrl>https://github.com/coronabytes/dotnet-arangodb-extensions</PackageProjectUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-	<PackageReference Include="Core.Arango" Version="3.11.4" />
+	<PackageReference Include="Core.Arango" Version="3.11.5" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Since the function parameters were changed with 3.11.5, this introduced a binary breaking change to the Extensions. This should be fixed by updating the version so it can link them correctly.