### PR TITLE
Improve Serilog Configuration Options

### DIFF
--- a/Core.Arango.Serilog/ArangoSerilogSink.cs
+++ b/Core.Arango.Serilog/ArangoSerilogSink.cs
@@ -12,9 +12,36 @@ namespace Core.Arango.Serilog
 {
     public class ArangoSerilogSink : IBatchedLogEventSink
     {
+        [Flags]
+        public enum LoggingRenderStrategy
+        {
+            RenderMessage = 1,
+            StoreTemplate = 2,
+        }
+
         private readonly IArangoContext _arango;
         private readonly string _collection;
         private readonly string _database;
+        private readonly LoggingRenderStrategy _renderMessage = LoggingRenderStrategy.RenderMessage;
+        private readonly bool _indexLevel;
+        private readonly bool _indexTimestamp;
+        private readonly bool _indexTemplate;
+
+        public ArangoSerilogSink(
+            IArangoContext arango,
+            string database = "logs",
+            string collection = "logs",
+            LoggingRenderStrategy renderMessage = LoggingRenderStrategy.RenderMessage,
+            bool indexLevel = false,
+            bool indexTimestamp = false,
+            bool indexTemplate = false) : this(arango, database, collection)
+        {
+            _renderMessage = renderMessage;
+            _indexLevel = indexLevel;
+            _indexTimestamp = indexTimestamp;
+            _indexTemplate = indexTemplate;
+        }
+
 
         public ArangoSerilogSink(
             IArangoContext arango,
@@ -27,10 +54,14 @@ namespace Core.Arango.Serilog
 
             try
             {
-                if (!_arango.Database.ExistAsync(_database).Result)
+                if (!_arango.Database.ExistAsync(_database).AsTask().GetAwaiter().GetResult())
                     _arango.Database.CreateAsync(_database).AsTask().Wait();
 
-                if (!_arango.Collection.ExistAsync(_database, collection).Result)
+                var indexes = _arango.Index.ListAsync(_database, _collection)
+                    .AsTask().GetAwaiter().GetResult();
+
+                if (!_arango.Collection.ExistAsync(_database, collection).AsTask().GetAwaiter().GetResult())
+                {
                     _arango.Collection.CreateAsync(_database, new ArangoCollection
                     {
                         Name = _collection,
@@ -39,6 +70,37 @@ namespace Core.Arango.Serilog
                             Type = ArangoKeyType.Padded
                         }
                     }).AsTask().Wait();
+                }
+
+                if (_indexLevel &&
+                    indexes.Any(x => x.Name == nameof(LogEventEntity.Level)))
+                {
+                    _arango.Index.CreateAsync(_database, _collection, new ArangoIndex
+                    {
+                        Type = ArangoIndexType.Persistent,
+                        Name = nameof(LogEventEntity.Level)
+                    }).AsTask().Wait();
+                }
+
+                if (_indexTimestamp &&
+                    indexes.Any(x => x.Name == nameof(LogEventEntity.Timestamp)))
+                {
+                    _arango.Index.CreateAsync(_database, _collection, new ArangoIndex
+                    {
+                        Type = ArangoIndexType.Persistent,
+                        Name = nameof(LogEventEntity.Timestamp)
+                    }).AsTask().Wait();
+                }
+                
+                if (_indexTemplate &&
+                    indexes.Any(x => x.Name == nameof(LogEventEntity.MessageTemplate)))
+                {
+                    _arango.Index.CreateAsync(_database, _collection, new ArangoIndex
+                    {
+                        Type = ArangoIndexType.Persistent,
+                        Name = nameof(LogEventEntity.MessageTemplate)
+                    }).AsTask().Wait();
+                }
             }
             catch (Exception)
             {
@@ -54,9 +116,16 @@ namespace Core.Arango.Serilog
                 {
                     Level = x.Level.ToString(),
                     Timestamp = x.Timestamp.UtcDateTime,
-                    Message = x.RenderMessage(),
+                    Message = _renderMessage.HasFlag(LoggingRenderStrategy.RenderMessage)
+                        ? x.RenderMessage()
+                        : null,
+                    MessageTemplate =
+                        _renderMessage.HasFlag(LoggingRenderStrategy.StoreTemplate)
+                            ? x.MessageTemplate.Text
+                            : null,
                     Exception = x.Exception?.ToString(),
-                    Properties = x.Properties.ToDictionary(y => y.Key,
+                    Properties = x.Properties.ToDictionary(
+                        y => y.Key,
                         y => y.Value.ToString())
                 }));
             }
@@ -78,9 +147,17 @@ namespace Core.Arango.Serilog
             public string Key { get; set; }
 
             public DateTime Timestamp { get; set; }
+
             public string Level { get; set; }
+
+            [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public string Message { get; set; }
+
+            [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+            public string MessageTemplate { get; set; }
+
             public string Exception { get; set; }
+
             public Dictionary<string, string> Properties { get; set; }
         }
     }

--- a/Core.Arango.Serilog/ArangoSerilogSink.cs
+++ b/Core.Arango.Serilog/ArangoSerilogSink.cs
@@ -22,7 +22,7 @@ namespace Core.Arango.Serilog
         private readonly IArangoContext _arango;
         private readonly string _collection;
         private readonly string _database;
-        private readonly LoggingRenderStrategy _renderMessage = LoggingRenderStrategy.RenderMessage;
+        private readonly LoggingRenderStrategy _renderMessage;
         private readonly bool _indexLevel;
         private readonly bool _indexTimestamp;
         private readonly bool _indexTemplate;

--- a/Core.Arango.Serilog/ArangoSerilogSink.cs
+++ b/Core.Arango.Serilog/ArangoSerilogSink.cs
@@ -112,15 +112,18 @@ namespace Core.Arango.Serilog
         {
             try
             {
+                var renderMessage = _renderMessage.HasFlag(LoggingRenderStrategy.RenderMessage);
+                var storeTemplate = _renderMessage.HasFlag(LoggingRenderStrategy.StoreTemplate);
+                
                 await _arango.Document.CreateManyAsync(_database, _collection, events.Select(x => new LogEventEntity
                 {
                     Level = x.Level.ToString(),
                     Timestamp = x.Timestamp.UtcDateTime,
-                    Message = _renderMessage.HasFlag(LoggingRenderStrategy.RenderMessage)
+                    Message = renderMessage
                         ? x.RenderMessage()
                         : null,
                     MessageTemplate =
-                        _renderMessage.HasFlag(LoggingRenderStrategy.StoreTemplate)
+                        storeTemplate
                             ? x.MessageTemplate.Text
                             : null,
                     Exception = x.Exception?.ToString(),

--- a/README.md
+++ b/README.md
@@ -196,10 +196,17 @@ builder.Host.UseSerilog(
     (c, log) =>
     {
         var arango = builder.Configuration.GetConnectionString("Arango");
+        var sink = new ArangoSerilogSink(new ArangoContext(arango), 
+            database: "logs", 
+            logs: "logs", 
+            renderMessage: ArangoSerilogSink.LoggingRenderStrategy.RenderMessage | ArangoSerilogSink.LoggingRenderStrategy.StoreTemplate , 
+            indexLevel: true,
+            indexTimestamp: true,
+            indexTemplate: true);
 
         log.Enrich.FromLogContext();
         log.WriteTo.Console(theme: AnsiConsoleTheme.Code);
-        log.WriteTo.Sink(new PeriodicBatchingSink(new ArangoSerilogSink(new ArangoContext(arango)), new PeriodicBatchingSinkOptions
+        log.WriteTo.Sink(new PeriodicBatchingSink(sink, new PeriodicBatchingSinkOptions
         {
             BatchSizeLimit = 1000,
             QueueLimit = 100000,


### PR DESCRIPTION
## Goal
Allow the indexing of important elements of logging, for quicker recall.
Allows the usage of the MessageTemplate and Message options independent of each-other, allowing indexing on MessageTemplate and reducing storage requirements.

## Changes
* Adds Message-Templating options, and whether or not to Render the Message
* Adds Indexing options for Level, Timestamp, and MessageTemplate
* It uses a separate Constructor to not create Binary Breaking Changes.


WARNING: This is untested, as this repo has no Unit Tests for Serilog Logging. 